### PR TITLE
Add compatibility with Symfony 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "type": "library",
     "license": "proprietary",
     "require": {
-        "php": "^7.2|^8.0",
-        "phpmyadmin/motranslator": "^5.2"
+        "php": "^7.1 || ^8.0",
+        "phpmyadmin/motranslator": "^5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "overtrue/phplint": "^2.4|^3.0",
-        "phpstan/phpstan": "^0.12"
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "overtrue/phplint": "^2.4 || ^3.0 || ^4.0",
+        "phpstan/phpstan": "^1.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`"phpmyadmin/motranslator": "dev-master"` will need to be modified with the corresponding tag when master is tagged