### PR TITLE
[FRM-8894] Use fallback translator only if the translation does not exist 

### DIFF
--- a/src/Gammadia/i18n/Translator.php
+++ b/src/Gammadia/i18n/Translator.php
@@ -74,11 +74,11 @@ class Translator
      */
     public function translate($msgId, array $params = [], bool $capitalize = true): string
     {
-        $value = $this->translatorLoader->getTranslator()->gettext($msgId);
+        $translator = $this->translatorLoader->getTranslator();
 
-        if ($value === $msgId) {
-            $value = $this->fallbackTranslatorLoader->getTranslator()->gettext($msgId);
-        }
+        $value = $translator->exists($msgId)
+            ? $translator->gettext($msgId)
+            : $this->fallbackTranslatorLoader->getTranslator()->gettext($msgId);
 
         $keys = array_map(function ($key) {
             return sprintf('{%s}', $key);


### PR DESCRIPTION
(as it may exist *and* be identical to the key)